### PR TITLE
Revert "fix(oci/charts/k8s-gateway): update 3.6.0 ➼ 3.6.1"

### DIFF
--- a/kube/deploy/core/dns/internal/k8s-gateway/app/chart.yaml
+++ b/kube/deploy/core/dns/internal/k8s-gateway/app/chart.yaml
@@ -12,4 +12,4 @@ spec:
     operation: copy
   url: oci://ghcr.io/k8s-gateway/charts/k8s-gateway
   ref:
-    tag: "3.6.1"
+    tag: "3.6.0"


### PR DESCRIPTION
Reverts JJGadgets/Biohazard#5377

somehow this release causes the HR to be stuck "installing" despite deployment pods and service being healthy and serving traffic, until the HR timeout is reached and the pods are yeeted, causing downtime on all my apps